### PR TITLE
Relax obs requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ const_file : <path>/CLON_CLAT_ICON-CH1.gb2
 station_obs_file : <path>/pollen_measured_2024020118.atab
 station_mod_file : <path>/pollen_modelled_2024020118.atab
 hour_incr : 1
+max_miss_stns : 4
 ```
 `pov_infile`: This GRIB2 file must include the fields `tthrs`, `tthre` (for POAC, `saisl` instead), `saisn` and `ctsum` if the module `update_phenology` is called. If the module `update_strength` is called `pov_infile` must include the fields `saisn` and `tune`. If at least one of these mandatory fields is missing the package exits with status 1 and tells the user. `pov_infile` is used as template for `pov_outfile`, i.e. the whole file is copied to `pov_outfile` with adapted values. Date and time information of `pov_infile` does not have to be correct, ICON just throws warnings.
 
@@ -119,6 +120,10 @@ hour_incr : 1
 `station_obs_file`: Observed hourly pollen concentrations (ATAB format) of the latest 120 hours relative to the target date of `pov_outfile`. The timestamps of the data in this file may vary depending on data availability, time of extraction etc. Missing values are allowed but at least 50% of each station must be there. If not, the package exits with status 1 and tells the user.
 `station_mod_file`: Modelled hourly pollen concentrations (ATAB format) of the latest 120 hours relative to the target date of `pov_outfile`. The timestamps of the data in this file may vary depending on data availability, time of extraction etc. In case of missing values the package exits with status 1 and tells the user. Same stations as in `station_obs_file` (only used if the module `update_strength` is called).
 `hour_incr`: Increment of the timestamp of the outfile relative to the infile in hours (defaults to 1; negative values also supported). This parameter should be adapted if the calibration is done for a subsequent run more than one hour ahead.
+`max_miss_stns`: Maximum number of stations with more than 50% missing observations. If
+there are less than 50% missing observation per station, they are replaced by the mean
+of the remaining observations; if there are more than 50% missing observations per station,
+the station is removed from pollen calibration. If there are more stations removed than mas_miss_stns, the pollen calibration is stopped and an alert is issued.
 
 
 ### How to run the package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "realtime-pollen-calibration"
-version = "1.1.0"
+version = "1.2.0"
 description = "Simon Adamov's Realtime Pollen Calibration, ICON extension by Andreas Pauling"
 readme = "README.md"
 keywords = [

--- a/src/realtime_pollen_calibration/set_up.py
+++ b/src/realtime_pollen_calibration/set_up.py
@@ -33,6 +33,8 @@ def set_up_config(config_file: str):
 
     config.pov_outfile = data["pov_outfile"]
 
+    config.max_miss_stns = data["max_miss_stns"]
+
     config.hour_incr = data["hour_incr"]
 
     return config

--- a/src/realtime_pollen_calibration/update_phenology.py
+++ b/src/realtime_pollen_calibration/update_phenology.py
@@ -133,7 +133,10 @@ def update_phenology_realtime(config_obj: utils.Config, verbose: bool = True):
     dict_fields = {}
     for pollen_type in utils.get_pollen_type(ds):
         obs_mod_data = utils.read_atab(
-            pollen_type, config_obj.station_obs_file, verbose=verbose
+            pollen_type,
+            config_obj.max_miss_stns,
+            config_obj.station_obs_file,
+            verbose=verbose,
         )
         change_phenology_fields = utils.get_change_phenol(
             pollen_type, obs_mod_data, ds, verbose

--- a/src/realtime_pollen_calibration/update_strength.py
+++ b/src/realtime_pollen_calibration/update_strength.py
@@ -102,6 +102,7 @@ def update_strength_realtime(config_obj: utils.Config, verbose: bool = True):
     for pollen_type in ptype_present:
         obs_mod_data = utils.read_atab(
             pollen_type,
+            config_obj.max_miss_stns,
             config_obj.station_obs_file,
             config_obj.station_mod_file,
             verbose=verbose,

--- a/src/realtime_pollen_calibration/utils.py
+++ b/src/realtime_pollen_calibration/utils.py
@@ -276,7 +276,7 @@ def create_data_arrays(cal_fields, clon, clat, time_values):
     return cal_fields_arrays
 
 
-def treat_missing(  # pylint: disable=too-many-positional-arguments
+def treat_missing( # pylint: disable=too-many-positional-arguments,too-many-arguments
     array,
     headerdata,
     max_miss_stns,

--- a/src/realtime_pollen_calibration/utils.py
+++ b/src/realtime_pollen_calibration/utils.py
@@ -276,7 +276,7 @@ def create_data_arrays(cal_fields, clon, clat, time_values):
     return cal_fields_arrays
 
 
-def treat_missing( # pylint: disable=too-many-positional-arguments,too-many-arguments
+def treat_missing(  # pylint: disable=too-many-positional-arguments,too-many-arguments
     array,
     headerdata,
     max_miss_stns,

--- a/src/realtime_pollen_calibration/utils.py
+++ b/src/realtime_pollen_calibration/utils.py
@@ -276,7 +276,7 @@ def create_data_arrays(cal_fields, clon, clat, time_values):
     return cal_fields_arrays
 
 
-def treat_missing(  # pylint: disable=too-many-arguments
+def treat_missing(  # pylint: disable=too-many-positional-arguments
     array,
     headerdata,
     max_miss_stns,

--- a/tests/test_realtime_pollen_calibration/test_utils.py
+++ b/tests/test_realtime_pollen_calibration/test_utils.py
@@ -38,8 +38,10 @@ def test_interpolation():
         encode_cf=("time", "geography", "vertical"),
     )
     obs_mod_data = utils.read_atab(
-        "ALNU",
-        str(here()) + "/RTcal_testdata/alnu_pollen_measured_values_2022022207.atab",
+        pollen_type="ALNU",
+        max_miss_stns=2,
+        file_obs_stns=str(here())
+        + "/RTcal_testdata/alnu_pollen_measured_values_2022022207.atab",
     )
     ######################
     # Specify the test

--- a/tools/get_data_and_test.sh
+++ b/tools/get_data_and_test.sh
@@ -19,6 +19,7 @@ const_file : $localpath/RTcal_testdata/CLON_CLAT_ICON-CH1.gb2
 station_obs_file : $localpath/RTcal_testdata/pollen_measured_2024020118.atab
 station_mod_file : $localpath/RTcal_testdata/pollen_modelled_2024020118.atab
 hour_incr : 1
+max_miss_stns : 4
 EOF
 
 # activate conda env


### PR DESCRIPTION
Now a configurable number of stations can have more than 50% missing observations (via config.yaml). The pollen calibration is stopped if that number is exceeded